### PR TITLE
Fix for apikey

### DIFF
--- a/MAPI.class.php
+++ b/MAPI.class.php
@@ -39,8 +39,8 @@ class MCAPI {
     public function __construct($apikey, $secure=false) {
         $this->secure = $secure;
         $aAPIKey = explode("-", $apikey);
-        $apikey = sprintf("http://%s.api.mailchimp.com/%.1f/?output=php", $aAPIKey[1], $this->version);
-        $this->apiUrl = parse_url($apikey);
+        $apiURL = sprintf("http://%s.api.mailchimp.com/%.1f/?output=php", $aAPIKey[1], $this->version);
+        $this->apiUrl = parse_url($apiURL);
         $this->api_key = $apikey;
     }
     function setTimeout($seconds){


### PR DESCRIPTION
Fix for this commit:

https://github.com/jbrooksuk/MCAPI-PHP/commit/c91854d354ee1d95e442876069a1de086c5430cb

... which broke the API by using the URL as they key!